### PR TITLE
Implement add, remove, sync and list commands

### DIFF
--- a/add.go
+++ b/add.go
@@ -1,0 +1,12 @@
+package main
+
+var cmdAdd = &Command{
+	Usage: "add",
+	Short: "add a new machine",
+	Run:   runAdd,
+}
+
+func runAdd(cmd *Command, args []string) {
+	createStorageIfNotExists()
+
+}

--- a/common.go
+++ b/common.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"json/encoding"
-  "fmt"
 	"os"
 )
 

--- a/common.go
+++ b/common.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"json/encoding"
+  "fmt"
+	"os"
+)
+
+const (
+  DefaultUser = "ubuntu"
+  StorageDest = "$HOME/.awssh/machines"
+)
+
+type Machine struct {
+	Name    string `json:"name"`
+	User    string `json:"user"`
+	Address string `json:"host"`
+}
+
+func fileExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return true, err
+}
+
+func createStorageIfNotExists() {
+	expandedDest := os.ExpandEnv(StorageDest)
+	storageExists, err := fileExists(expandedDest)
+	fail(err)
+
+	if !storageExists {
+		err = os.MkdirAll(expandedDest, 0777)
+		fail(err)
+	}
+}
+
+func fail(err error) {
+	if err != nil {
+		panic(err)
+	}
+}

--- a/list.go
+++ b/list.go
@@ -1,11 +1,11 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
-  "path"
-  "encoding/json"
+	"path"
 )
 
 var cmdList = &Command{
@@ -14,18 +14,38 @@ var cmdList = &Command{
 	Run:   runList,
 }
 
-func runList() {
-	createStorageIfNotExists()
+func getFiles() []os.FileInfo {
 	machinesDir := os.ExpandEnv(StorageDest)
 	fileInfos, _ := ioutil.ReadDir(machinesDir)
 
-  fmt.Printf("%-20s %-10s %s\n", " Name", " User", " Address")
-  fmt.Printf("%-20s %-10s %s\n", "-----------------", "------", "---------")
+	return fileInfos
+}
+
+func getMachine(fileInfo os.FileInfo) *Machine {
+  machinesDir := os.ExpandEnv(StorageDest)
+	filePath := path.Join(machinesDir, fileInfo.Name())
+	fileContent, _ := ioutil.ReadFile(filePath)
+	machine := &Machine{}
+	json.Unmarshal(fileContent, &machine)
+
+  return machine
+}
+
+func writeHeaders() {
+	fmt.Printf("%-20s %-10s %s\n", " Name", " User", " Address")
+	fmt.Printf("%-20s %-10s %s\n", "-----------------", "------", "---------")
+}
+
+func writeMachine(machine *Machine) {
+	fmt.Printf("%-20s %-10s %s\n", machine.Name, machine.User, machine.Address)
+}
+
+func runList(cmd *Command, args []string) {
+	createStorageIfNotExists()
+	fileInfos := getFiles()
+
 	for _, fileInfo := range fileInfos {
-    filePath := path.Join(machinesDir, fileInfo.Name())
-    fileContent, _ := ioutil.ReadFile(filePath)
-    machine := &Machine{}
-    json.Unmarshal(fileContent, &machine)
-    fmt.Printf("%-20s %-10s %s\n", machine.Name, machine.User, machine.Address)
+		machine := getMachine(fileInfo)
+		writeMachine(machine)
 	}
 }

--- a/list.go
+++ b/list.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+  "path"
+  "encoding/json"
+)
+
+var cmdList = &Command{
+	Usage: "list",
+	Short: "list the saves machines",
+	Run:   runList,
+}
+
+func runList() {
+	createStorageIfNotExists()
+	machinesDir := os.ExpandEnv(StorageDest)
+	fileInfos, _ := ioutil.ReadDir(machinesDir)
+
+  fmt.Printf("%-20s %-10s %s\n", " Name", " User", " Address")
+  fmt.Printf("%-20s %-10s %s\n", "-----------------", "------", "---------")
+	for _, fileInfo := range fileInfos {
+    filePath := path.Join(machinesDir, fileInfo.Name())
+    fileContent, _ := ioutil.ReadFile(filePath)
+    machine := &Machine{}
+    json.Unmarshal(fileContent, &machine)
+    fmt.Printf("%-20s %-10s %s\n", machine.Name, machine.User, machine.Address)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -41,13 +41,13 @@ var commands = []*Command{
 }
 
 func main() {
-	flag.Usage = usageExit
+	flag.Usage = UsageExit
 	flag.Parse()
 	log.SetFlags(0)
 	log.SetPrefix("awssh: ")
 	args := flag.Args()
 	if len(args) < 1 {
-		usageExit()
+		UsageExit()
 	}
 
 	if args[0] == "help" {
@@ -123,7 +123,13 @@ Usage: awssh {{.Usage}}
 {{.Short | trim}}
 `
 
-func usageExit() {
+func UsageExit() {
 	printUsage(os.Stderr)
+	os.Exit(2)
+}
+
+func (c *Command) UsageExit() {
+	fmt.Fprintf(os.Stderr, "Usage: awssh %s\n\n", c.Usage)
+	fmt.Fprintf(os.Stderr, "Run 'awssh help %s' for help.\n", c.Name())
 	os.Exit(2)
 }

--- a/remove.go
+++ b/remove.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+  os
+)
+
+var cmdRemove = &Command{
+	Usage: "remove",
+	Short: "remove a machine",
+	Run:   runRemove,
+}
+
+func machineFile(name string) bool {
+	machinesDir := os.ExpandEnv(StorageDest)
+  filePath := path.Join(
+}
+
+func runRemove(cmd *Command, args []string) {
+	createStorageIfNotExists()
+
+}

--- a/sync.go
+++ b/sync.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"os"
+  "path"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+var cmdSync = &Command{
+	Usage: "sync",
+	Short: "syncs your ec2 machines with awssh",
+	Run:   runSync,
+}
+
+func runSync(cmd *Command, args []string) {
+  createStorageIfNotExists()
+
+	svc := ec2.New(session.New(), &aws.Config{})
+	validateRegion(svc)
+	validateCredentials(svc)
+
+	fmt.Println(*svc.Config.Region)
+
+	resp, err := svc.DescribeInstances(nil)
+	fail(err)
+
+	var machine *Machine
+
+	for _, reservation := range resp.Reservations {
+		for _, instance := range reservation.Instances {
+
+			// The AWS sdk will fail if the instance isn't running
+			if *instance.State.Name == "running" {
+				address := instanceAddress(instance)
+				name := instanceName(instance)
+				user := instanceUser(instance)
+
+				fmt.Println(address, name, user)
+				machine = &Machine{
+					Address: address,
+					Name:    name,
+					User:    user,
+				}
+				machine.Save()
+			}
+		}
+	}
+}
+
+func validateRegion(svc *ec2.EC2) {
+	if len(*svc.Config.Region) == 0 {
+		fmt.Println("[error] AWS_REGION not set")
+		showHelpAndExit()
+	}
+}
+
+func validateCredentials(svc *ec2.EC2) {
+	credentials, err := (svc.Config.Credentials.Get())
+	fail(err)
+
+	if len(credentials.AccessKeyID) == 0 {
+		fmt.Println("[error] AWS_ACCESS_KEY_ID not set")
+		showHelpAndExit()
+	}
+	if len(credentials.SecretAccessKey) == 0 {
+		fmt.Println("[error] AWS_SECRET_ACCESS_KEY not set")
+		showHelpAndExit()
+	}
+}
+
+func formatName(name string) string {
+	lowercased := strings.ToLower(name)
+	return strings.Replace(lowercased, " ", "-", -1)
+}
+
+func instanceAddress(instance *ec2.Instance) string {
+	address := *instance.PublicDnsName
+	if len(address) == 0 {
+		address = *instance.PublicIpAddress
+	}
+	return address
+}
+
+func instanceName(instance *ec2.Instance) string {
+	for _, value := range instance.Tags {
+		if *value.Key == "Name" {
+			return formatName(*value.Value)
+		}
+	}
+	return "n/a"
+}
+
+func instanceUser(instance *ec2.Instance) string {
+	return DefaultUser
+}
+
+func (machine *Machine) Save() {
+	fmt.Println("Saving: ", machine.Name)
+	filePath := path.Join(os.ExpandEnv(StorageDest), machine.Name)
+	machineJson, err := json.Marshal(machine)
+	if err == nil {
+		err = ioutil.WriteFile(filePath, machineJson, 0777)
+		if err == nil {
+			return
+		}
+	}
+	fmt.Println("Could not save: ", machine.Name)
+}
+
+`

--- a/sync.go
+++ b/sync.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"encoding/json"
-	"io"
+	"fmt"
 	"io/ioutil"
 	"os"
-  "path"
+	"path"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -20,13 +20,11 @@ var cmdSync = &Command{
 }
 
 func runSync(cmd *Command, args []string) {
-  createStorageIfNotExists()
+	createStorageIfNotExists()
 
 	svc := ec2.New(session.New(), &aws.Config{})
 	validateRegion(svc)
 	validateCredentials(svc)
-
-	fmt.Println(*svc.Config.Region)
 
 	resp, err := svc.DescribeInstances(nil)
 	fail(err)
@@ -57,7 +55,7 @@ func runSync(cmd *Command, args []string) {
 func validateRegion(svc *ec2.EC2) {
 	if len(*svc.Config.Region) == 0 {
 		fmt.Println("[error] AWS_REGION not set")
-		showHelpAndExit()
+		os.Exit(2)
 	}
 }
 
@@ -67,11 +65,11 @@ func validateCredentials(svc *ec2.EC2) {
 
 	if len(credentials.AccessKeyID) == 0 {
 		fmt.Println("[error] AWS_ACCESS_KEY_ID not set")
-		showHelpAndExit()
+		os.Exit(2)
 	}
 	if len(credentials.SecretAccessKey) == 0 {
 		fmt.Println("[error] AWS_SECRET_ACCESS_KEY not set")
-		showHelpAndExit()
+		os.Exit(2)
 	}
 }
 
@@ -113,5 +111,3 @@ func (machine *Machine) Save() {
 	}
 	fmt.Println("Could not save: ", machine.Name)
 }
-
-`


### PR DESCRIPTION
This introduces the list, add, remove and sync (with aws) commands (command structure inspired by godep). 

Each command will now be their own files and will need to be added to the `commands` list in `main.go`. This makes the tool easier to extend and organize. 

Commands:
- `add` will allow users to add machines manually
- `remove` will allow users to remove machines manually
- `sync` command will automatically delete all existing machine settings and add machines based off instances on s3.
